### PR TITLE
Fix play after pause crash

### DIFF
--- a/Pod/Classes/LSPAudioViewController.m
+++ b/Pod/Classes/LSPAudioViewController.m
@@ -151,7 +151,6 @@ static void * LSPAudioViewControllerContext = &LSPAudioViewControllerContext;
 {
     DELEGATE_SAFELY(self.delegate, @selector(audioViewController:willPlayPlayer:), [self.delegate audioViewController:self willPlayPlayer:self.player];)
     
-    [self.audioQueuePlayer removeTimeObserver:_progressObserver];
     [self.player play];
     __weak __typeof(self)weakself = self;
     _progressObserver = [self.audioQueuePlayer addPeriodicTimeObserverForInterval:self.observationInterval queue:NULL usingBlock:^(CMTime time) {

--- a/loudspeaker.podspec
+++ b/loudspeaker.podspec
@@ -9,7 +9,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "loudspeaker"
-  s.version          = "0.1.2"
+  s.version          = "0.1.3"
   s.summary          = "An AVQueuePlayer-backed audio player with a modern, minimal UI"
   s.description      = <<-DESC
                        An audio player with a modern, minimal UI. Powered by AVQueuePlayer.


### PR DESCRIPTION
Extra call of `removeTimeObserver:` caused a crush in `play` function in `LSPAudioViewController`. In code time observer removed in `pause` function.
