### PR TITLE
Use try/catch around KVO unsubscribe to prevent exceptions from escaping

### DIFF
--- a/Pod/Classes/LSPAudioViewController.m
+++ b/Pod/Classes/LSPAudioViewController.m
@@ -91,7 +91,11 @@ static void * LSPAudioViewControllerContext = &LSPAudioViewControllerContext;
     [self stop];
     [self removeTimeObserver];
     
-    [self removeObserver:self forKeyPath:@"playing" context:&LSPAudioViewControllerContext];
+    @try
+    {
+        [self removeObserver:self forKeyPath:@"playing" context:&LSPAudioViewControllerContext];
+    }
+    @catch (NSException * __unused exception) {}
     
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     


### PR DESCRIPTION
This stops crashing when `reset` is called more than once on an instance of `LSPAudioViewController`.
