### PR TITLE
Do view setup in viewDidLoad, not before.

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -14,7 +14,7 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   loudspeaker:
-    :path: "../"
+    :path: ../
 
 SPEC CHECKSUMS:
   Expecta: 32604574add2c46a36f8d2f716b6c5736eb75024

--- a/Pod/Classes/LSPAudioViewController.h
+++ b/Pod/Classes/LSPAudioViewController.h
@@ -43,7 +43,6 @@
 - (void)play;
 - (void)playAudioWithURL:(NSURL *)url;
 - (void)reset;
-- (void)setup;
 - (void)stop;
 
 @end

--- a/Pod/Classes/LSPAudioViewController.m
+++ b/Pod/Classes/LSPAudioViewController.m
@@ -41,34 +41,16 @@ static void * LSPAudioViewControllerContext = &LSPAudioViewControllerContext;
 @dynamic view;
 
 #pragma mark - Lifecycle
-- (instancetype)init
-{
-    self = [super init];
-    if (!self) return nil;
-    
-    [self setup];
-    
-    return self;
-}
-
-
-+ (instancetype)new
-{
-    LSPAudioViewController *audioVC = [self.class.alloc init];
-    if (!audioVC) return nil;
-    
-    return audioVC;
-}
-
-
 - (void)viewDidAppear:(BOOL)animated
 {
     [super viewDidAppear:animated];
 }
 
 
-- (void)setup
+- (void)viewDidLoad
 {
+    [super viewDidLoad];
+    
     self.view = [LSPAudioView newAutoLayoutView];
     [self.view.closeButton addTarget:self action:@selector(closeButtonPressed:) forControlEvents:UIControlEventTouchUpInside];
     [self.view.playPauseButton addTarget:self action:@selector(togglePlayPause:) forControlEvents:UIControlEventTouchUpInside];


### PR DESCRIPTION
This doesn't get around the `view` still being set to an `LSPAudioView` instance _in_ `viewDidLoad` but it's a better place in the lifecycle to do all of the other setup tasks.
