### PR TITLE
Remove accessor methods in initialization

### DIFF
--- a/Pod/Classes/LSPAudioViewController.h
+++ b/Pod/Classes/LSPAudioViewController.h
@@ -43,7 +43,6 @@
 - (void)play;
 - (void)playAudioWithURL:(NSURL *)url;
 - (void)reset;
-- (void)setup;
 - (void)stop;
 
 @end

--- a/Pod/Classes/LSPAudioViewController.m
+++ b/Pod/Classes/LSPAudioViewController.m
@@ -46,19 +46,12 @@ static void * LSPAudioViewControllerContext = &LSPAudioViewControllerContext;
     self = [super init];
     if (!self) return nil;
 
-    [self setup];
+    // Every .35 of a second.
+    _observationInterval = CMTimeMake(1, 35);
+    _player = LSPAudioPlayer.sharedInstance;
+    _audioQueuePlayer = LSPAudioPlayer.player;
 
     return self;
-}
-
-
-- (void)setup
-{
-    self.player = LSPAudioPlayer.sharedInstance;
-    self.audioQueuePlayer = LSPAudioPlayer.player;
-
-    // Every .35 of a second.
-    self.observationInterval = CMTimeMake(1, 35);
 }
 
 


### PR DESCRIPTION
To make the code safer per http://qualitycoding.org/objective-c-init/ and https://developer.apple.com/library/mac/#documentation/Cocoa/Conceptual/MemoryMgmt/Articles/mmPractical.html, the accessor methods were removed from the `init` of `LSPAudioViewController`.

@adamyanalunas - Please inspect.
